### PR TITLE
Component System Prototype 1

### DIFF
--- a/DungeonGenerator/.gitignore
+++ b/DungeonGenerator/.gitignore
@@ -46,6 +46,7 @@ ExportedObj/
 *.mdb
 *.opendb
 *.VC.db
+*.vsconfig
 
 # Unity3D generated meta files
 *.pidb.meta

--- a/DungeonGenerator/Assets/Scenes/BrianScene.meta
+++ b/DungeonGenerator/Assets/Scenes/BrianScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef6b6b6f226f08c48a0e1187649468c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DungeonGenerator/Assets/Scenes/BrianScene/Comps.unity
+++ b/DungeonGenerator/Assets/Scenes/BrianScene/Comps.unity
@@ -1,0 +1,591 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &569518255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 569518256}
+  - component: {fileID: 569518257}
+  m_Layer: 0
+  m_Name: ComponentSaveDeath
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &569518256
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 569518255}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.9336365, y: -5.1974816, z: 13.011175}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &569518257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 569518255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6e104020efc36d47b282bdf26595dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1270599582}
+--- !u!1 &662164220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 662164223}
+  - component: {fileID: 662164222}
+  - component: {fileID: 662164221}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &662164221
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662164220}
+  m_Enabled: 1
+--- !u!20 &662164222
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662164220}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &662164223
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662164220}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1270599580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1270599583}
+  - component: {fileID: 1270599582}
+  - component: {fileID: 1270599581}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1270599581
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1270599580}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 1021671597, guid: 59eeace978a281c43b041d5eb4c53178, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1270599582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1270599580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a301694853814dc4490b9fd5d6fac428, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1270599583
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1270599580}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1324922081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1324922082}
+  - component: {fileID: 1324922083}
+  m_Layer: 0
+  m_Name: ComponentWeirdMove
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1324922082
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1324922081}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.9336365, y: -5.1974816, z: 13.011175}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1324922083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1324922081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2748effa7a02a274ba776e563d22282a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1270599582}
+--- !u!1 &2036575255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2036575257}
+  - component: {fileID: 2036575256}
+  m_Layer: 0
+  m_Name: bkg
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &2036575256
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036575255}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 3625043607559282579, guid: 19fb86013d8c24d6cb8410c0aadf30fa, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 0.5}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2036575257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036575255}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.941371, y: 3.4952135, z: 0}
+  m_LocalScale: {x: 5.4283, y: 5.4283, z: 5.4283}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2041665287
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2041665289}
+  - component: {fileID: 2041665288}
+  m_Layer: 0
+  m_Name: ComponentTiltCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2041665288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041665287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 903e07ffc14445149b0bfa9ce9a1fd75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1270599582}
+--- !u!4 &2041665289
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041665287}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.8897266, y: -3.930337, z: 13.484869}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2056942293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2056942294}
+  - component: {fileID: 2056942295}
+  m_Layer: 0
+  m_Name: ComponentFastMove
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2056942294
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056942293}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.9336365, y: -5.1974816, z: 13.011175}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2056942295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056942293}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e6c5f5ca590750469fc3f7a3633a6da, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1270599582}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 662164223}
+  - {fileID: 2056942294}
+  - {fileID: 1324922082}
+  - {fileID: 569518256}
+  - {fileID: 1270599583}
+  - {fileID: 2041665289}
+  - {fileID: 2036575257}

--- a/DungeonGenerator/Assets/Scenes/BrianScene/Comps.unity.meta
+++ b/DungeonGenerator/Assets/Scenes/BrianScene/Comps.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: be84e15b7f932cf408fe5d8b43bc0c77
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DungeonGenerator/Assets/Scripts/BrianScripts.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a35eed5e1fa616d4d9a32ee7eee259aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentFastMove.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentFastMove.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace BCho
+{
+    public class ComponentFastMove : MonoBehaviour
+    {
+        [SerializeField] Player player;
+
+        /* Treat this as OnCollisionEnter2D on the weapon pickup, and the weapon pickup calls smth like `ApplyComponents()` */
+        private void Start()
+        {   
+            player.SubMove(Effect);
+        }
+
+        private void Effect(MoveInfo info)
+        {
+            info.Speed += 2;
+        }
+
+    }
+
+    
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentFastMove.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentFastMove.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e6c5f5ca590750469fc3f7a3633a6da

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentSaveDeath.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentSaveDeath.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace BCho
+{
+    public class ComponentSaveDeath : MonoBehaviour
+    {
+        [SerializeField] Player player;
+
+        /* maybe it even acquires a component list so later it can search to see if player has a certain component to stave off death */
+        private void Start()
+        {
+            player.SubDeath(Effect);
+        }
+
+        private void Effect(DeathInfo info)
+        {
+            if (player.transform.position.x < 0)
+            {
+                /* Problem: 
+                 * - the component breaks after being used, but what if there is 
+                 *   another 'cursed' component that nullifies the effect?
+                 * */
+                Debug.Log("Player was saved by ComponentC! ComponentC breaks...");
+                info.ShouldDie = false;
+                Destroy(this);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            player.UnsubDeath(Effect);
+        }
+    }
+
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentSaveDeath.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentSaveDeath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6e104020efc36d47b282bdf26595dd0

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentTiltCam.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentTiltCam.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace BCho
+{
+    public class ComponentTiltCam : MonoBehaviour
+    {
+        [SerializeField] Player player;
+
+        /* maybe it even acquires a component list so later it can search to see if player has a certain component to stave off death */
+        private void Start()
+        {
+            player.SubInteract(Effect);
+        }
+
+        private void Effect(InteractInfo info)
+        {
+            Debug.Log($"Something weird happened!");
+            Camera.main.transform.SetLocalPositionAndRotation(Camera.main.transform.position, Quaternion.Euler(0, 0, Random.Range(-10, 10)));
+        }
+    }
+
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentTiltCam.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentTiltCam.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 903e07ffc14445149b0bfa9ce9a1fd75

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentWeirdMove.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentWeirdMove.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace BCho
+{
+    public class ComponentWeirdMove : MonoBehaviour
+    {
+        [SerializeField] Player player;
+        private void Start()
+        {
+            player.SubMove(Effect);
+        }
+
+        private void Effect(MoveInfo info)
+        {
+            if (info.Direction.x > 0)
+            {
+                Debug.Log($"Broke ComponentB! Can move down now!");
+                Destroy(this);
+                return;
+            }
+
+            if (info.Direction.y < 0)
+            {
+                info.Direction = -1 * info.Direction;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            player.UnsubMove(Effect);
+        }
+    }
+
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentWeirdMove.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/ComponentWeirdMove.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2748effa7a02a274ba776e563d22282a

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/DeathInfo.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/DeathInfo.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace BCho
+{
+    public class DeathInfo
+    {
+        public bool ShouldDie { get; set; }
+
+        public DeathInfo()
+        {
+            ShouldDie = true;
+        }
+    }
+
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/DeathInfo.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/DeathInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3a79fde830df1a4f9ad4f8df1b27f2b

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/InteractInfo.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/InteractInfo.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class InteractInfo
+{
+    
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/InteractInfo.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/InteractInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 35c5190f8d3774b47bbd7d8ce030c21a

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/MoveInfo.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/MoveInfo.cs
@@ -1,0 +1,18 @@
+using UnityEditor.Experimental.GraphView;
+using UnityEngine;
+
+namespace BCho
+{
+    public class MoveInfo
+    {
+        public Vector2 Direction { get; set; }
+        public float Speed { get; set; }
+
+        public MoveInfo(Vector2 direction, float speed)
+        {
+            Direction = direction;
+            Speed = speed;
+        }
+    }
+
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/MoveInfo.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/MoveInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e252c9104eec454cb5d99b16f8141bd

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/Player.cs
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/Player.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+using System.Collections.Generic;
+using UnityEngine.Events;
+namespace BCho
+{
+    public class Player : MonoBehaviour
+    {
+        UnityEvent<MoveInfo> m_eventMove;
+        UnityEvent<DeathInfo> m_eventDeath;
+        UnityEvent<InteractInfo> m_eventInteract;
+
+
+        const float BASE_SPEED = 2.0f;
+
+        private void Awake()
+        {
+            m_eventMove = new();
+            m_eventDeath = new();
+            m_eventInteract = new();
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
+            Vector2 direction = Vector2.zero;
+            if (Input.GetKey(KeyCode.A))
+            {
+                direction += Vector2.left;
+            }
+            else if (Input.GetKey(KeyCode.D))
+            {
+                direction += Vector2.right;
+            }
+
+            if (Input.GetKey(KeyCode.W))
+            {
+                direction += Vector2.up;
+            }
+            else if (Input.GetKey(KeyCode.S))
+            {
+                direction += Vector2.down;
+            }
+
+            if (direction != Vector2.zero)
+            {
+                MoveInfo moveInfo = new(direction.normalized, BASE_SPEED);
+                m_eventMove.Invoke(moveInfo);
+                //Debug.Log($"{moveInfo.Direction} : {moveInfo.Speed}");
+                transform.position += (Vector3)(moveInfo.Direction.normalized * moveInfo.Speed * Time.deltaTime);
+            }
+
+            /* Kill player */
+            if (Input.GetKeyDown(KeyCode.Space))
+            {
+                DeathInfo deathInfo = new();  // by default, player should die
+                m_eventDeath.Invoke(deathInfo);
+                if (!deathInfo.ShouldDie)
+                {
+
+                    Debug.Log($"Player not die  :  ) ");
+                }
+                else
+                {
+                    Debug.Log($"Player die :(");
+                }
+            }
+
+            if (Input.GetKeyDown(KeyCode.F))
+            {
+                InteractInfo interactInfo = new();
+                m_eventInteract.Invoke(interactInfo);
+                /* no use for interactInfo yet */
+            }
+        }
+
+        public void SubInteract(UnityAction<InteractInfo> action)
+        {
+            m_eventInteract.AddListener(action);
+        }
+
+        public void UnsubInteract(UnityAction<InteractInfo> action)
+        {
+            m_eventInteract.RemoveListener(action);
+        }
+
+        public void SubMove(UnityAction<MoveInfo> action)
+        {
+            m_eventMove.AddListener(action);
+        }
+
+        public void UnsubMove(UnityAction<MoveInfo> action)
+        {
+            m_eventMove.RemoveListener(action);
+        }
+
+        public void SubDeath(UnityAction<DeathInfo> action)
+        {
+            m_eventDeath.AddListener(action);
+        }
+
+        public void UnsubDeath(UnityAction<DeathInfo> action)
+        {
+            m_eventDeath.RemoveListener(action);
+        }
+    }
+}

--- a/DungeonGenerator/Assets/Scripts/BrianScripts/Player.cs.meta
+++ b/DungeonGenerator/Assets/Scripts/BrianScripts/Player.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a301694853814dc4490b9fd5d6fac428


### PR DESCRIPTION
System is okay. It can be improved or there is a better system.

It's a pub-sub system, so instead of the Player needing to know about the components, the components need to know about the player. This might be good since we might want to apply affects to something other than the Player (ex. ComponentTiltCam).

Only problem is that, we have less control over the order in which the effects are applied. For example, ComponentSaveDeath saves the player from death, but what if there was a curse Component that nullifies the protection effect? (maybe we can fix it by looking up if the player has the curse component before applying the saved death effect.)

Another problem is the context that these components are given (ex. MoveInfo, DeathInfo). MoveInfo has a `direction` and `speed` value. Components modify these values, and the player uses the final modification.
But what if we want a component that multiplies the base speed instead of the modified speed? Then we would have to either change MoveInfo to {direction, mulspeed, addspeed} and then do `(basespeed * mulspeed + addspeed) * direction.normalized` in player, or we have to return Action objects and let the player sort it and apply in order.
The problem I try to highlight is that `speed` is now deprecated, and therefore might mean that we need to update all components to not use `speed`. However, maybe we can just keep adding new variables (ex. {direction, speed, mulspeed, addspeed}). An old component might update `speed`, but a newer component might update `mulspeed` and `addspeed`, and the player would account for all the variables.